### PR TITLE
Update 32-bit & 64-bit test paths to reflect name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn input_buffer_write_protection_32() {
-        test_input_buffer_write_protection("out/test_input_buffer_write_protection_64/");
+        test_input_buffer_write_protection("out/test_input_buffer_write_protection_32/");
     }
 
     #[test]
@@ -636,7 +636,7 @@ mod tests {
 
     #[test]
     fn input_buffer_write_protection_child_32() {
-        test_input_buffer_write_protection_child("out/test_input_buffer_write_protection_64/");
+        test_input_buffer_write_protection_child("out/test_input_buffer_write_protection_32/");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -697,7 +697,7 @@ mod tests {
 
     #[test]
     fn set_agent_configuration_twice_64(){
-        test_early_abort("out/test_set_agent_configuration_twice_32/", "KVM_EXIT_KAFL_SET_AGENT_CONFIG called twice...")
+        test_early_abort("out/test_set_agent_configuration_twice_64/", "KVM_EXIT_KAFL_SET_AGENT_CONFIG called twice...")
     }
 
     #[test]


### PR DESCRIPTION
Adjusted the paths used in the 32-bit version of the tests to use the 32-bit binaries.
Adjusted the 64-bit agent configuration test to use the 64-bit binary.